### PR TITLE
Always return undef from _Value on permission denied

### DIFF
--- a/lib/RT/Asset.pm
+++ b/lib/RT/Asset.pm
@@ -622,7 +622,7 @@ Checks L</CurrentUserCanSee> before calling C<SUPER::_Value>.
 
 sub _Value {
     my $self = shift;
-    return unless $self->CurrentUserCanSee;
+    return undef unless $self->CurrentUserCanSee;
     return $self->SUPER::_Value(@_);
 }
 


### PR DESCRIPTION
The bare return will produce an empty list when called in list context.  This
produced "Odd number of elements in hash assignment" warnings when ->Catalog
was used in the parameter list for LoadByNameAndCatalog inside
LoadCustomFieldByIdentifier.

DBIx::SearchBuilder::Record's _Value (by way of __Value) makes sure to always
return a scalar.

---

This is untested but by inspection should fix the warning.  I'll see if it silences the warnings I'm seeing reported logwatch in the next few days.
